### PR TITLE
feat: add sub and sup types to the mark resolvers

### DIFF
--- a/example/lib/demoContent.ts
+++ b/example/lib/demoContent.ts
@@ -1,181 +1,199 @@
 export const demoContent = {
-  'type': 'doc',
-  'content': [
+  type: "doc",
+  content: [
     {
-      'type': 'heading',
-      'attrs': {
-        'level': 1
+      type: "heading",
+      attrs: {
+        level: 1,
       },
-      'content': [
+      content: [
         {
-          'text': 'Headline',
-          'type': 'text'
-        }
-      ]
+          text: "Headline",
+          type: "text",
+        },
+      ],
     },
     {
-      'type': 'paragraph',
-      'content': [
+      type: "paragraph",
+      content: [
         {
-          'text': 'This is some Rich Text Editor',
-          'type': 'text'
+          text: "This is some Rich Text Editor",
+          type: "text",
         },
         {
-          'type': 'hard_break'
+          type: "hard_break",
         },
         {
-          'text': 'You ',
-          'type': 'text'
+          text: "You ",
+          type: "text",
         },
         {
-          'text': 'can',
-          'type': 'text',
-          'marks': [
+          text: "can",
+          type: "text",
+          marks: [
             {
-              'type': 'italic'
-            }
-          ]
+              type: "italic",
+            },
+          ],
         },
         {
-          'text': ' ',
-          'type': 'text'
+          text: " ",
+          type: "text",
         },
         {
-          'text': 'try',
-          'type': 'text',
-          'marks': [
+          text: "try",
+          type: "text",
+          marks: [
             {
-              'type': 'underline'
-            }
-          ]
+              type: "underline",
+            },
+          ],
         },
         {
-          'text': ' ',
-          'type': 'text'
+          text: " ",
+          type: "text",
         },
         {
-          'text': 'some',
-          'type': 'text',
-          'marks': [
+          text: "different",
+          type: "text",
+          marks: [
             {
-              'type': 'bold'
-            }
-          ]
+              type: "subscript",
+            },
+          ],
         },
         {
-          'text': ' ',
-          'type': 'text'
-        },
-        {
-          'text': 'styling',
-          'type': 'text',
-          'marks': [
+          text: "markups",
+          type: "text",
+          marks: [
             {
-              'type': 'strike'
-            }
-          ]
-        }
-      ]
+              type: "superscript",
+            },
+          ],
+        },
+        {
+          text: "some",
+          type: "text",
+          marks: [
+            {
+              type: "bold",
+            },
+          ],
+        },
+        {
+          text: " ",
+          type: "text",
+        },
+        {
+          text: "styling",
+          type: "text",
+          marks: [
+            {
+              type: "strike",
+            },
+          ],
+        },
+      ],
     },
     {
-      'type': 'bullet_list',
-      'content': [
+      type: "bullet_list",
+      content: [
         {
-          'type': 'list_item',
-          'content': [
+          type: "list_item",
+          content: [
             {
-              'type': 'paragraph',
-              'content': [
+              type: "paragraph",
+              content: [
                 {
-                  'text': 'one',
-                  'type': 'text'
-                }
-              ]
-            }
-          ]
+                  text: "one",
+                  type: "text",
+                },
+              ],
+            },
+          ],
         },
         {
-          'type': 'list_item',
-          'content': [
+          type: "list_item",
+          content: [
             {
-              'type': 'paragraph',
-              'content': [
+              type: "paragraph",
+              content: [
                 {
-                  'text': 'two',
-                  'type': 'text'
-                }
-              ]
-            }
-          ]
+                  text: "two",
+                  type: "text",
+                },
+              ],
+            },
+          ],
         },
         {
-          'type': 'list_item',
-          'content': [
+          type: "list_item",
+          content: [
             {
-              'type': 'paragraph',
-              'content': [
+              type: "paragraph",
+              content: [
                 {
-                  'text': 'three',
-                  'type': 'text'
-                }
-              ]
-            }
-          ]
-        }
-      ]
+                  text: "three",
+                  type: "text",
+                },
+              ],
+            },
+          ],
+        },
+      ],
     },
     {
-      'type': 'ordered_list',
-      'attrs': {
-        'order': 1
+      type: "ordered_list",
+      attrs: {
+        order: 1,
       },
-      'content': [
+      content: [
         {
-          'type': 'list_item',
-          'content': [
+          type: "list_item",
+          content: [
             {
-              'type': 'paragraph',
-              'content': [
+              type: "paragraph",
+              content: [
                 {
-                  'text': 'one',
-                  'type': 'text'
-                }
-              ]
-            }
-          ]
+                  text: "one",
+                  type: "text",
+                },
+              ],
+            },
+          ],
         },
         {
-          'type': 'list_item',
-          'content': [
+          type: "list_item",
+          content: [
             {
-              'type': 'paragraph',
-              'content': [
+              type: "paragraph",
+              content: [
                 {
-                  'text': 'two',
-                  'type': 'text'
-                }
-              ]
-            }
-          ]
+                  text: "two",
+                  type: "text",
+                },
+              ],
+            },
+          ],
         },
         {
-          'type': 'list_item',
-          'content': [
+          type: "list_item",
+          content: [
             {
-              'type': 'paragraph',
-              'content': [
+              type: "paragraph",
+              content: [
                 {
-                  'text': 'three',
-                  'type': 'text'
-                }
-              ]
-            }
-          ]
-        }
-      ]
+                  text: "three",
+                  type: "text",
+                },
+              ],
+            },
+          ],
+        },
+      ],
     },
     {
-      'type': 'paragraph'
-    }
-  ]
-}
+      type: "paragraph",
+    },
+  ],
+};

--- a/src/resolver/mark.ts
+++ b/src/resolver/mark.ts
@@ -1,9 +1,12 @@
-import { LinkAttributes as LA, StyledAttributes } from '@marvr/storyblok-rich-text-types'
-import { ReactNode, createElement, FC } from 'react'
+import {
+  LinkAttributes as LA,
+  StyledAttributes,
+} from "@marvr/storyblok-rich-text-types";
+import { ReactNode, createElement, FC } from "react";
 
 type LinkAttributes = LA & {
-  anchor?: string
-}
+  anchor?: string;
+};
 
 export type StoryblokRichtextMark =
   | "bold"
@@ -14,21 +17,30 @@ export type StoryblokRichtextMark =
   | "link"
   | "styled";
 
-const simpleMarkResolver = (element: string | FC) => (children: ReactNode): JSX.Element | null =>
-  createElement(element, null, children)
+const simpleMarkResolver =
+  (element: string | FC) =>
+  (children: ReactNode): JSX.Element | null =>
+    createElement(element, null, children);
 
 export const defaultMarkResolvers = {
-  link: (children: ReactNode, { href, linktype, target }: LinkAttributes): JSX.Element | null =>
-    createElement('a', {
-      href: linktype === 'email' ? `mailto:${href}` : href,
-      target
-    }, children),
+  link: (
+    children: ReactNode,
+    { href, linktype, target }: LinkAttributes
+  ): JSX.Element | null =>
+    createElement(
+      "a",
+      {
+        href: linktype === "email" ? `mailto:${href}` : href,
+        target,
+      },
+      children
+    ),
   styled: (children: ReactNode, attrs: StyledAttributes): JSX.Element | null =>
-    createElement('span', { className: attrs.class }, children),
-  bold: simpleMarkResolver('b'),
-  strong: simpleMarkResolver('strong'),
-  italic: simpleMarkResolver('i'),
-  strike: simpleMarkResolver('s'),
-  underline: simpleMarkResolver('u'),
-  code: simpleMarkResolver('code')
-}
+    createElement("span", { className: attrs.class }, children),
+  bold: simpleMarkResolver("b"),
+  strong: simpleMarkResolver("strong"),
+  italic: simpleMarkResolver("i"),
+  strike: simpleMarkResolver("s"),
+  underline: simpleMarkResolver("u"),
+  code: simpleMarkResolver("code"),
+};


### PR DESCRIPTION
PR to fix this issue: #6 

Storyblok has updated their content with subscript and superscript resolvers, and the library is missing them so I just used some simple resolvers and add them.

Although there are no formatter rules so I just let my config do the trick, oops! @dohomi as it's your project I'll let you set it up 😄  

Have a good day 👋 
